### PR TITLE
[FIX] Corrige a url da API Homolog para hmg.snc

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -32,7 +32,7 @@ Cypress.Commands.add('api', () => {
   cy.server()           // enable response stubbing
   cy.route({
     method: 'GET',      // Route all GET requests
-    url: 'http://snchomolog.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=&cnpj_prefeitura=',    // that have a URL that matches '/users/*'
+    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=&cnpj_prefeitura=',    // that have a URL that matches '/users/*'
     response: 'fixture:entidadeResponse'        // and force the response to be: []
   })
  });
@@ -41,7 +41,7 @@ Cypress.Commands.add('apiSimples', () => {
   cy.server()           // enable response stubbing
   cy.route({
     method: 'GET',      // Route all GET requests
-    url: 'http://snchomolog.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=Malhada&estado_sigla=&cnpj_prefeitura=',    // that have a URL that matches '/users/*'
+    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=Malhada&estado_sigla=&cnpj_prefeitura=',    // that have a URL that matches '/users/*'
     response: 'fixture:entidade.json'        // and force the response to be: []
   })
 });
@@ -50,7 +50,7 @@ Cypress.Commands.add('api_busca_uf', () => {
   cy.server()           // enable response stubbing
   cy.route({
     method: 'GET',      // Route all GET requests
-    url: 'http://snchomolog.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=DF&cnpj_prefeitura=',    // that have a URL that matches '/users/*'
+    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=DF&cnpj_prefeitura=',    // that have a URL that matches '/users/*'
     response: 'fixture:entidadeResponse'        // and force the response to be: []
   })
  });
@@ -59,7 +59,7 @@ Cypress.Commands.add('api_busca_cnpj', () => {
   cy.server()           // enable response stubbing
   cy.route({
     method: 'GET',      // Route all GET requests
-    url: 'http://snchomolog.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=&cnpj_prefeitura=14.105.217/0001-70',    // that have a URL that matches '/users/*'
+    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=&cnpj_prefeitura=14.105.217/0001-70',    // that have a URL that matches '/users/*'
     response: 'fixture:entidade.json'        // and force the response to be: []
   })
 });

--- a/src/app/slc-api.service.ts
+++ b/src/app/slc-api.service.ts
@@ -16,7 +16,7 @@ import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 @Injectable()
 export class SlcApiService {
 
-  private sncUrlHmgLocal = 'http://snchomolog.cultura.gov.br/api/v1/sistemadeculturalocal/';
+  private sncUrlHmgLocal = 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/';
   private sncUrlLocal = 'http://localhost:8000/api/v1/sistemadeculturalocal';
   private listaRetorno = {};
   private buscar = new BehaviorSubject<any>([]);


### PR DESCRIPTION
O VerSNC estava consumindo as informações da API alocada em um servidor que não utilizamos mais. 
Atualizando para o link correto.