### PR TITLE
[UPDATE] Pesquisa por nome do ente federado na Busca Simples

### DIFF
--- a/cypress/integration/main.spec.ts
+++ b/cypress/integration/main.spec.ts
@@ -62,12 +62,30 @@ describe('' +
       cy.get('app-root snc-table mat-card mat-table mat-row').should('not.be.empty');
     });
 
-    it('Testa input Estado/Municipio da Busca Simples e retorno respectivo na tabela', () => {
+    it('Testa pesquisa do Nome do Município na Busca Simples', () => {
       cy.apiSimples();
       cy.visit('http://localhost:4200/');
       cy.get('input').type('Malhada{enter}');
       cy.get('app-root snc-table mat-card mat-table mat-row mat-cell').eq(0).contains(' Malhada - BA ');
     });
+
+    it('Testa pesquisa do Nome do Estado por extenso na Busca Simples', () => {
+      cy.api_busca_uf();
+      cy.visit('http://localhost:4200/');
+      cy.get('input').type('Distrito Federal{enter}');
+      cy.get('app-root snc-table mat-card mat-table mat-row mat-cell').eq(0).contains(' Brasília - DF ');
+      cy.get('app-root snc-table mat-card mat-table mat-row mat-cell').eq(3).contains(' Distrito Federal ');
+    });
+
+
+    it('Testa pesquisa da Sigla do Estado por extenso na Busca Simples', () => {
+      cy.api_busca_uf();
+      cy.visit('http://localhost:4200/');
+      cy.get('input').type('DF{enter}');
+      cy.get('app-root snc-table mat-card mat-table mat-row mat-cell').eq(0).contains(' Brasília - DF ');
+      cy.get('app-root snc-table mat-card mat-table mat-row mat-cell').eq(3).contains(' Distrito Federal ');
+    });
+
 
     it('Testa mudança da Busca Simples p/ Busca Avançada após click no botão de Abrir Filtros', () => {
       cy.api();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -32,7 +32,7 @@ Cypress.Commands.add('api', () => {
   cy.server()           // enable response stubbing
   cy.route({
     method: 'GET',      // Route all GET requests
-    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=&data_adesao_min=&data_adesao_max=&nome_uf=&estadual=&municipal=',    
+    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=&data_adesao_min=&data_adesao_max=&nome_uf=&estadual=&municipal=&ente_federado=',    
     response: 'fixture:entidadeResponse'        // and force the response to be: []
   })
  });
@@ -41,7 +41,7 @@ Cypress.Commands.add('apiSimples', () => {
   cy.server()           // enable response stubbing
   cy.route({
     method: 'GET',      // Route all GET requests
-    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=Malhada&estado_sigla=&data_adesao_min=&data_adesao_max=&nome_uf=&estadual=&municipal=',    
+    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=Malhada&estado_sigla=&data_adesao_min=&data_adesao_max=&nome_uf=&estadual=&municipal=&ente_federado=',    
     response: 'fixture:entidade.json'        // and force the response to be: []
   })
 });
@@ -50,7 +50,7 @@ Cypress.Commands.add('api_busca_uf', () => {
   cy.server()           // enable response stubbing
   cy.route({
     method: 'GET',      // Route all GET requests
-    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=DF&data_adesao_min=&data_adesao_max=&nome_uf=&estadual=&municipal=',    
+    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=DF&data_adesao_min=&data_adesao_max=&nome_uf=&estadual=&municipal=&ente_federado=',    
     response: 'fixture:entidadeResponse'        // and force the response to be: []
   })
  });
@@ -59,7 +59,7 @@ Cypress.Commands.add('api_data_adesao_min', () => {
   cy.server()           // enable response stubbing
   cy.route({
     method: 'GET',      // Route all GET requests
-    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=&data_adesao_min=11/10/2017&data_adesao_max=&nome_uf=&estadual=&municipal=',    
+    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=&data_adesao_min=11/10/2017&data_adesao_max=&nome_uf=&estadual=&municipal=&ente_federado=',    
     response: 'fixture:adesao_11-10-2017'        // and force the response to be: []
   })
 });
@@ -68,7 +68,7 @@ Cypress.Commands.add('api_data_adesao_max', () => {
   cy.server()           // enable response stubbing
   cy.route({
     method: 'GET',      // Route all GET requests
-    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=&data_adesao_min=&data_adesao_max=1/1/2016&nome_uf=&estadual=&municipal=',    
+    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=&data_adesao_min=&data_adesao_max=1/1/2016&nome_uf=&estadual=&municipal=&ente_federado=',    
     response: 'fixture:adesao_ate_1-1-2016'        // and force the response to be: []
   })
 });
@@ -77,7 +77,7 @@ Cypress.Commands.add('api_df', () => {
   cy.server()           // enable response stubbing
   cy.route({
     method: 'GET',      // Route all GET requests
-    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=&data_adesao_min=&data_adesao_max=&nome_uf=Distrito Federal',    // that have a URL that matches '/users/*'
+    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=&data_adesao_min=&data_adesao_max=&nome_uf=Distrito Federal&ente_federado=',    // that have a URL that matches '/users/*'
     response: 'fixture:DistritoFederal'        // and force the response to be: []
   })
 });
@@ -85,7 +85,7 @@ Cypress.Commands.add('api_somente_municipios', () => {
   cy.server()           // enable response stubbing
   cy.route({
     method: 'GET',      // Route all GET requests
-    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=BA&data_adesao_min=&data_adesao_max=&nome_uf=&estadual=false&municipal=',    
+    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=BA&data_adesao_min=&data_adesao_max=&nome_uf=&estadual=false&municipal=&ente_federado=',    
     response: 'fixture:municipalResponse'        // and force the response to be: []
   })
 });
@@ -94,7 +94,7 @@ Cypress.Commands.add('api_somente_estados', () => {
   cy.server()           // enable response stubbing
   cy.route({
     method: 'GET',      // Route all GET requests
-    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=&data_adesao_min=&data_adesao_max=&nome_uf=&estadual=&municipal=false',    
+    url: 'http://hmg.snc.cultura.gov.br/api/v1/sistemadeculturalocal/?limit=&offset=&nome_municipio=&estado_sigla=&data_adesao_min=&data_adesao_max=&nome_uf=&estadual=&municipal=false&ente_federado=',    
     response: 'fixture:estadualResponse'        // and force the response to be: []
   })
 });

--- a/src/app/busca/busca.component.spec.ts
+++ b/src/app/busca/busca.component.spec.ts
@@ -45,7 +45,7 @@ describe('BuscaComponent', () => {
     component['termoSimples'] = 'df';
     component.onRealizarBuscaComEnter(event);
 
-    expect(component['queries']['estado_sigla']).toEqual('DF');
+    expect(component['queries']['ente_federado']).toEqual('DF');
     expect(component['queries']['nome_municipio']).toEqual('');
   });
 
@@ -53,7 +53,7 @@ describe('BuscaComponent', () => {
     component['termoSimples'] = 'Brasília';
     component.onRealizarBuscaComEnter(event);
 
-    expect(component['queries']['nome_municipio']).toEqual('Brasília');
+    expect(component['queries']['ente_federado']).toEqual('Brasília');
     expect(component['queries']['estado_sigla']).toEqual('');
   });
 
@@ -71,7 +71,7 @@ describe('BuscaComponent', () => {
   
     component.onRealizarBuscaComEnter(event);
     expect(component['termoSimples']).toBe('Barreiras');
-    expect(component.queries['nome_municipio']).toBe('Barreiras');
+    expect(component.queries['ente_federado']).toBe('Barreiras');
 
   }));
 
@@ -84,7 +84,7 @@ describe('BuscaComponent', () => {
   
     component.onRealizarBuscaComEnter(event);
     expect(component['termoSimples']).toBe('pe');
-    expect(component.queries['estado_sigla']).toBe('PE');
+    expect(component['queries']['ente_federado']).toBe('PE');
   }));
   
   it('Verifica método que trata a pesquisa pelo nome do Estado por extenso - Busca Avançada', inject([SlcApiService], (service: SlcApiService) => {

--- a/src/app/busca/busca.component.ts
+++ b/src/app/busca/busca.component.ts
@@ -38,7 +38,7 @@ export class BuscaComponent implements OnInit {
   queries: { [query: string]: String }
     = {
       'limit': '', 'offset': '', 'nome_municipio': '', 'estado_sigla': '', 'data_adesao_min': '', 'data_adesao_max': '',
-      'nome_uf': '', 'estadual': '', 'municipal': ''
+      'nome_uf': '', 'estadual': '', 'municipal': '', 'ente_federado': ''
     };
 
 
@@ -54,16 +54,7 @@ export class BuscaComponent implements OnInit {
       if (!this.seletorTipoBusca) { // BUSCA SIMPLES
         this.queries['estadual'] = '';
         this.queries['municipal'] = '';
-        if (this.termoSimples.length < 3) {
-          this.queries['nome_municipio'] = '';
-          this.queries['offset'] = '';
-          this.queries['estado_sigla'] = this.termoSimples.toUpperCase();
-        } else if (this.termoSimples === '' || this.termoSimples.length > 2) {
-          this.queries['estado_sigla'] = '';
-          this.queries['offset'] = '';
-          this.queries['nome_municipio'] = this.termoSimples;
-
-        }
+        this.queries['ente_federado'] = this.termoSimples.length < 3 ? this.termoSimples.toUpperCase() : this.termoSimples;
         this.onRealizarBusca();
 
       } else { // BUSCA AVANÇADA
@@ -79,7 +70,7 @@ export class BuscaComponent implements OnInit {
   }
 
   pesquisarEstado(nome_uf) {
-    this.queries['estado_sigla'] = nome_uf.length < 3 ? nome_uf.toUpperCase() : '';
+    this.queries['estado_sigla'] = nome_uf.length == 2 ? nome_uf.toUpperCase() : '';
     this.queries['nome_uf'] = nome_uf.length > 2 ? nome_uf : '';
   }
 

--- a/src/app/slc-api.service.ts
+++ b/src/app/slc-api.service.ts
@@ -63,17 +63,16 @@ export class SlcApiService {
     return this.http.get(this.sncUrlHmgLocal, { params: queries })
       .map(res => {
 
-        let count: Number = 0;
+        let count: number = 0;
         let entesFederados: Entidade[] = [];
         count = res['count'];
-
         entesFederados = res['_embedded']['items'].map((element, index) => {
           const entidade: Entidade = {
             'id': '', 'ente_federado': '', 'situacao_adesao': '',
             'conselho': '', 'acoes_plano_trabalho': '', 'link_entidade': '',
             'link_plano_trabalho_entidade': '', 'nome_municipio': '', 'criacao_lei_sistema': '',
             'criacao_conselho_cultural': '', 'criacao_orgao_gestor': '', 'criacao_fundo_cultura': '',
-            'criacao_plano_cultura': '', 'sigla_estado': '', 'data_adesao': '', 'municipioUF': '', 'nome_estado': ''
+            'criacao_plano_cultura': '', 'sigla_estado': '', 'data_adesao': '', 'municipioUF': '', 'nome_estado': '',
           };
 
 
@@ -81,13 +80,13 @@ export class SlcApiService {
           entidade.ente_federado = element['ente_federado'];
 
           entidade.situacao_adesao = element['situacao_adesao'] ? String(element['situacao_adesao']['situacao_adesao']) : '';
-          entidade.conselho = element['conselho'] ? element['conselho'] : ''; 
+          entidade.conselho = element['conselho'] ? element['conselho'] : '';
 
           entidade.link_entidade = String(element['_links']['self']['href']);
           entidade.data_adesao = element['data_adesao'];
           entidade.nome_estado = element['ente_federado']['localizacao']['estado']['nome_uf'];
           entidade.sigla_estado = element['ente_federado']['localizacao']['estado']['sigla'];
-          
+
           entidade.acoes_plano_trabalho = element['_embedded']['acoes_plano_trabalho'];
           if (element['_embedded']['acoes_plano_trabalho'] !== null) {
             entidade.link_plano_trabalho_entidade = String(element['_embedded']['acoes_plano_trabalho']['_links']['self']['href']);
@@ -97,7 +96,7 @@ export class SlcApiService {
             // entidade.criacao_fundo_cultura = String(element['_embedded']['acoes_plano_trabalho']['criacao_fundo_cultura']['situacao']);
             // entidade.criacao_orgao_gestor = String(element['_embedded']['acoes_plano_trabalho']['criacao_orgao_gestor']['situacao']);
           }
-          
+
 
           if (element['ente_federado']['localizacao']['cidade'] !== null) {
             entidade.nome_municipio = String(element['ente_federado']['localizacao']['cidade']['nome_municipio']);
@@ -106,7 +105,6 @@ export class SlcApiService {
             entidade.nome_municipio = null;
             entidade.municipioUF = entidade.nome_estado;
           }
-
 
           return entidade;
         });


### PR DESCRIPTION
***- Utilização do campo 'ente_federado' da API para Busca Simples, permitindo pesquisar por:***
- Nome do Município
- Nome do Estado
- Sigla do Estado

***- Atualização das urls usadas pelo Cypress, adicionando 'ente_federado'***
***- Atualização dos testes pelo Jest na busca***