### PR TITLE
[FIX] Correção do comportamento busca avançada após a busca simples

### DIFF
--- a/src/app/busca/busca.component.ts
+++ b/src/app/busca/busca.component.ts
@@ -59,6 +59,7 @@ export class BuscaComponent implements OnInit {
 
       } else { // BUSCA AVANÇADA
         this.pesquisarEstado(this.termoUF);
+        this.queries['ente_federado'] = '';
         this.queries['data_adesao_min'] = this.getDatePicker(this.data_adesao_min);
         this.queries['data_adesao_max'] = this.getDatePicker(this.data_adesao_max);
         this.queries['estadual'] = !this.visualizarEstados ? 'false' : '';


### PR DESCRIPTION
- Determina o a querie 'ente_federado' como nula quando é feita uma busca avançada.

Erro que foi corrigido: Quando é feita uma busca simples e uma busca avançada em seguida, o resultado da busca avançada ficava restrita ao resultado da busca simples, dado que não ocorria a limpeza dos filtro de pesquisa (parâmetro 'ente_federado') da busca simples.